### PR TITLE
Added connected client count

### DIFF
--- a/HiddenWallet.ChaumianTumbler/TumblerHub.cs
+++ b/HiddenWallet.ChaumianTumbler/TumblerHub.cs
@@ -1,8 +1,21 @@
 ﻿using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
 
 namespace HiddenWallet.ChaumianTumbler
 {
 	public class TumblerHub : Hub
 	{
+		public override async Task OnConnectedAsync()
+		{
+			TumblerPhaseBroadcaster.Instance.AddConnectedClient(Context.ConnectionId);
+			await base.OnConnectedAsync();
+		}
+
+		public override async Task OnDisconnectedAsync(Exception exception)
+		{
+			TumblerPhaseBroadcaster.Instance.RemoveConnectedClient(Context.ConnectionId);
+			await base.OnDisconnectedAsync(exception);
+		}
 	}
 }

--- a/HiddenWallet.ChaumianTumbler/TumblerPhaseBroadcaster.cs
+++ b/HiddenWallet.ChaumianTumbler/TumblerPhaseBroadcaster.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.SignalR;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,12 +13,12 @@ namespace HiddenWallet.ChaumianTumbler
     {
 		private readonly static Lazy<TumblerPhaseBroadcaster> _instance = new Lazy<TumblerPhaseBroadcaster>(() => new TumblerPhaseBroadcaster());
 
-		private IHubContext<TumblerHub> _context; //The context of the hub - needed in order for the tumbler to act on MVC submitted data and call the hub to issue updates
+		private readonly ConcurrentDictionary<string, string> _connectedClients = new ConcurrentDictionary<string, string>();
 
+		private IHubContext<TumblerHub> _context;
+		
 		private TumblerPhaseBroadcaster()
- 		{
- 			//	Put any code to initliase collections etc. here.
- 		}
+ 		{ }
 
 		public static TumblerPhaseBroadcaster Instance => _instance.Value;
 
@@ -28,6 +29,12 @@ namespace HiddenWallet.ChaumianTumbler
 				_context = value;
 			}
 		}
+
+		public void AddConnectedClient(string id) => _connectedClients.TryAdd(id, id);
+
+		public void RemoveConnectedClient(string id) => _connectedClients.Remove(id, out string value);
+
+		public int ConnectedClientCount() => _connectedClients.Count();
 
 		public void Broadcast(PhaseChangeBroadcast broadcast)
 		{


### PR DESCRIPTION
Made connected client count available through TumblerPhaseBroadcaster for future use.

Checked and this works with javascript and the C# client. Connections are added to count and disconnects (closed tab, closed C# client) are removed.