### PR TITLE
Added package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ tor
 /HiddenWallet.Gui/Config.json
 /HiddenWallet.Daemon/Config.json
 /HiddenWallet.Gui/**/*.js
+/HiddenWallet.Gui/package-lock.json


### PR DESCRIPTION
This created when you run npm install for the first time. Not needed in github.